### PR TITLE
Fix unzip target for raw image

### DIFF
--- a/builder/build.sh
+++ b/builder/build.sh
@@ -90,7 +90,7 @@ fi
 # verify checksum of the ready-made raw image
 echo "${RAW_IMAGE_CHECKSUM} ${BUILD_RESULT_PATH}/${RAW_IMAGE}.zip" | sha256sum -c -
 
-unzip -p "${BUILD_RESULT_PATH}/${RAW_IMAGE}" > "/${HYPRIOT_IMAGE_NAME}"
+unzip -p "${BUILD_RESULT_PATH}/${RAW_IMAGE}.zip" > "/${HYPRIOT_IMAGE_NAME}"
 
 # create the image and add root base filesystem
 guestfish -a "/${HYPRIOT_IMAGE_NAME}"<<_EOF_


### PR DESCRIPTION
## Summary
- update raw image extraction in `build.sh` to use the `.zip` file

## Testing
- `make test` *(fails: `/bin/sh: 1: docker: not found`)*