### PR TITLE
Fix make command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Download the [latest development build here](https://jenkins.laboratoriopublico.
 Pre-requisites for running locally: You'll need to have Docker installed.
 
 ```
-make sd-card
+make sd-image
 ```
 
 This will create an image called `hypriotos-rpi-dirty.img.zip`.

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -103,7 +103,7 @@ guestfish -a "/${HYPRIOT_IMAGE_NAME}"<<_EOF_
   tar-in /image_with_kernel_boot.tar.gz /boot compress:gzip
 _EOF_
 
-# ensure that the CircleCI user can access the sd-card image file
+# ensure that the CircleCI user can access the sd-image file
 umask 0000
 
 # compress image


### PR DESCRIPTION
## Summary
- update README to use `make sd-image`
- update build script comment

## Testing
- `make test` *(fails: docker not found)*