### PR TITLE
Parameterize integration test versions

### DIFF
--- a/builder/test-integration/spec/hypriotos-image/docker-compose_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/docker-compose_spec.rb
@@ -6,8 +6,10 @@ describe file('/usr/local/bin/docker-compose') do
   it { should be_owned_by 'root' }
 end
 
+expected_version = RSpec.configuration.docker_compose_version || '1.21.1'
+
 describe command('docker-compose --version') do
-  its(:stdout) { should match /1.21.1/m }
+  its(:stdout) { should match /#{Regexp.escape(expected_version)}/m }
   its(:exit_status) { should eq 0 }
 end
 

--- a/builder/test-integration/spec/hypriotos-image/docker-machine_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/docker-machine_spec.rb
@@ -6,8 +6,10 @@ describe file('/usr/local/bin/docker-machine') do
   it { should be_owned_by 'root' }
 end
 
+expected_version = RSpec.configuration.docker_machine_version || '0.14.0'
+
 describe command('docker-machine --version') do
-  its(:stdout) { should match /0.14.0/m }
+  its(:stdout) { should match /#{Regexp.escape(expected_version)}/m }
   its(:exit_status) { should eq 0 }
 end
 

--- a/builder/test-integration/spec/hypriotos-image/docker_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/docker_spec.rb
@@ -8,9 +8,15 @@ describe package('docker-ce') do
   it { should be_installed }
 end
 
+package_version = RSpec.configuration.docker_ce_version
+
 describe command('dpkg -l docker-ce') do
   its(:stdout) { should match /ii  docker-ce/ }
-  its(:stdout) { should match /18.04.0~ce~3-0~raspbian/ }
+  if package_version
+    its(:stdout) { should match /#{Regexp.escape(package_version)}/ }
+  else
+    its(:stdout) { should match /18.04.0~ce~3-0~raspbian/ }
+  end
   its(:stdout) { should match /armhf/ }
   its(:exit_status) { should eq 0 }
 end
@@ -83,14 +89,23 @@ describe file('/etc/bash_completion.d/docker') do
   it { should be_file }
 end
 
+docker_version =
+  if package_version
+    ver = package_version.split(':').last
+    ver = ver.split('~').first
+    "#{ver}-ce"
+  else
+    '18.04.0-ce'
+  end
+
 describe command('docker -v') do
-  its(:stdout) { should match /Docker version 18.04.0-ce, build/ }
+  its(:stdout) { should match /Docker version #{Regexp.escape(docker_version)}, build/ }
   its(:exit_status) { should eq 0 }
 end
 
 describe command('docker version') do
-  its(:stdout) { should match /Client:. Version:	18.04.0-ce. API version:	1.37/m }
-  its(:stdout) { should match /Server:. Engine:.  Version:	18.04.0-ce.  API version:	1.37/m }
+  its(:stdout) { should match /Client:. Version:        #{Regexp.escape(docker_version)}. API version:        1.37/m }
+  its(:stdout) { should match /Server:. Engine:.  Version:      #{Regexp.escape(docker_version)}.  API version:       1.37/m }
   its(:exit_status) { should eq 0 }
 end
 

--- a/builder/test-integration/spec/spec_helper.rb
+++ b/builder/test-integration/spec/spec_helper.rb
@@ -19,3 +19,10 @@ end
 
 set :host,        options[:host_name] || host
 set :ssh_options, options
+
+# expose expected tool versions via RSpec configuration
+RSpec.configure do |config|
+  config.add_setting :docker_compose_version, default: ENV['DOCKER_COMPOSE_VERSION']
+  config.add_setting :docker_machine_version, default: ENV['DOCKER_MACHINE_VERSION']
+  config.add_setting :docker_ce_version,      default: ENV['DOCKER_CE_VERSION']
+end


### PR DESCRIPTION
## Summary
- allow specifying docker-compose version via ENV in tests
- allow specifying docker-machine version via ENV
- read docker-ce package version from ENV and derive binary version
- expose env vars through RSpec configuration

## Testing
- `bundle exec rspec --version` *(fails: rbenv: version `2.0.0' is not installed)*