### PR TITLE
Fix apt sources in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM hypriot/image-builder:latest
 
-RUN apt-get update && \
+RUN sed -i 's@deb.debian.org/debian@archive.debian.org/debian@g' /etc/apt/sources.list && \
+    sed -i 's@security.debian.org/debian-security@archive.debian.org/debian-security@g' /etc/apt/sources.list && \
+    sed -i 's@stretch-updates@@' /etc/apt/sources.list && \
+    echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99nocheck && \
+    apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
     binfmt-support \
     qemu \


### PR DESCRIPTION
## Summary
- patch outdated Debian stretch repositories in Dockerfile

## Testing
- `make test` *(fails: `docker: not found`)*