### PR TITLE
Fix invalid apt entry in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM hypriot/image-builder:latest
 
 RUN sed -i 's@deb.debian.org/debian@archive.debian.org/debian@g' /etc/apt/sources.list && \
     sed -i 's@security.debian.org/debian-security@archive.debian.org/debian-security@g' /etc/apt/sources.list && \
-    sed -i 's@stretch-updates@@' /etc/apt/sources.list && \
+    # remove the obsolete stretch-updates entry entirely to avoid malformed apt
+    # configuration after replacing the mirror URLs
+    sed -i '/stretch-updates/d' /etc/apt/sources.list && \
     echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99nocheck && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \


### PR DESCRIPTION
## Summary
- avoid malformed `sources.list` by deleting the `stretch-updates` line entirely

## Testing
- `make test` *(fails: `docker: not found`)*