### PR TITLE
Update Debian version to bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,6 @@
 FROM hypriot/image-builder:latest
 
-RUN sed -i 's@deb.debian.org/debian@archive.debian.org/debian@g' /etc/apt/sources.list && \
-    sed -i 's@security.debian.org/debian-security@archive.debian.org/debian-security@g' /etc/apt/sources.list && \
-    # remove the obsolete stretch-updates entry entirely to avoid malformed apt
-    # configuration after replacing the mirror URLs
-    sed -i '/stretch-updates/d' /etc/apt/sources.list && \
-    echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99nocheck && \
-    apt-get update && \
+RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
     binfmt-support \
     qemu \

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -95,7 +95,7 @@ mkdir -p "$(dirname "${DEST}")"
 echo "nameserver 8.8.8.8" > "${DEST}"
 
 # set up hypriot rpi repository for raspbian specific packages
-echo 'deb https://packagecloud.io/Hypriot/rpi/raspbian/ stretch main' >> /etc/apt/sources.list.d/hypriot.list
+echo 'deb https://packagecloud.io/Hypriot/rpi/raspbian/ bookworm main' >> /etc/apt/sources.list.d/hypriot.list
 curl -L https://packagecloud.io/Hypriot/rpi/gpgkey | apt-key add -
 
 # set up Docker CE repository
@@ -104,13 +104,13 @@ DOCKERREPO_KEY_URL=https://download.docker.com/linux/raspbian/gpg
 get_gpg "${DOCKERREPO_FPR}" "${DOCKERREPO_KEY_URL}"
 
 CHANNEL=edge # stable, test or edge
-echo "deb [arch=armhf] https://download.docker.com/linux/raspbian stretch $CHANNEL" > /etc/apt/sources.list.d/docker.list
+echo "deb [arch=armhf] https://download.docker.com/linux/raspbian bookworm $CHANNEL" > /etc/apt/sources.list.d/docker.list
 
 
 RPI_ORG_FPR=CF8A1AF502A2AA2D763BAE7E82B129927FA3303E RPI_ORG_KEY_URL=http://archive.raspberrypi.org/debian/raspberrypi.gpg.key
 get_gpg "${RPI_ORG_FPR}" "${RPI_ORG_KEY_URL}"
 
-echo 'deb http://archive.raspberrypi.org/debian/ stretch main' | tee /etc/apt/sources.list.d/raspberrypi.list
+echo 'deb http://archive.raspberrypi.org/debian/ bookworm main' | tee /etc/apt/sources.list.d/raspberrypi.list
 
 # reload package sources
 apt-get update

--- a/builder/test-integration/spec/hypriotos-image/docker_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/docker_spec.rb
@@ -15,7 +15,7 @@ describe command('dpkg -l docker-ce') do
   if package_version
     its(:stdout) { should match /#{Regexp.escape(package_version)}/ }
   else
-    its(:stdout) { should match /18.04.0~ce~3-0~raspbian/ }
+    its(:stdout) { should match /24.0.5~ce~3-0~debian/ }
   end
   its(:stdout) { should match /armhf/ }
   its(:exit_status) { should eq 0 }
@@ -95,7 +95,7 @@ docker_version =
     ver = ver.split('~').first
     "#{ver}-ce"
   else
-    '18.04.0-ce'
+    '24.0.5-ce'
   end
 
 describe command('docker -v') do

--- a/builder/test-integration/spec/hypriotos-image/hypriot-list_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/hypriot-list_spec.rb
@@ -4,7 +4,7 @@ describe file('/etc/apt/sources.list.d/hypriot.list') do
   it { should be_file }
   it { should be_mode 644 }
   it { should be_owned_by 'root' }
-  it { should contain 'deb https://packagecloud.io/Hypriot/rpi/debian/ stretch main' }
+  it { should contain 'deb https://packagecloud.io/Hypriot/rpi/debian/ bookworm main' }
 end
 
 describe package('apt-transport-https') do

--- a/builder/test-integration/spec/hypriotos-image/raspberrypi-list_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/raspberrypi-list_spec.rb
@@ -4,5 +4,5 @@ describe file('/etc/apt/sources.list.d/raspberrypi.list') do
   it { should be_file }
   it { should be_mode 644 }
   it { should be_owned_by 'root' }
-  it { should contain 'deb http://archive.raspberrypi.org/debian/ stretch main' }
+  it { should contain 'deb http://archive.raspberrypi.org/debian/ bookworm main' }
 end

--- a/builder/test/os-release_spec.rb
+++ b/builder/test/os-release_spec.rb
@@ -7,8 +7,8 @@ describe "Root filesystem" do
     expect(stdout).to contain('debian')
   end
 
-  it "is debian version stretch" do
-    expect(stdout).to contain('stretch')
+  it "is debian version bookworm" do
+    expect(stdout).to contain('bookworm')
   end
 
   it "is a HypriotOS" do

--- a/versions.config
+++ b/versions.config
@@ -13,6 +13,6 @@ export KERNEL_BUILD="1.20190517-1"
 # export KERNEL_URL=https://62-32913687-gh.circle-artifacts.com/0/home/circleci/project/output/20180320-092128/raspberrypi-kernel_20180320-092128_armhf.deb
 # export KERNEL_VERSION="4.14.98"
 export DOCKER_CE_CHANNEL="test" # stable, test or edge
-export DOCKER_CE_VERSION="5:19.03.0~2.2.rc2-0~raspbian-stretch"
+export DOCKER_CE_VERSION="5:24.0.5-1~debian.12~bookworm"
 export DOCKER_COMPOSE_VERSION="1.23.2"
 export DOCKER_MACHINE_VERSION="0.16.1"


### PR DESCRIPTION
## Summary
- update apt install steps in Dockerfile
- switch chroot scripts to bookworm repositories
- adjust test expectations for bookworm and Docker 24.0.5
- bump Docker CE version in config

## Testing
- `make test` *(fails: `/bin/sh: 1: docker: not found`)*